### PR TITLE
RDKEAPPRT-19 : Remove evergreen config in DAC SDK to support evergreen full

### DIFF
--- a/conf/rdk.inc
+++ b/conf/rdk.inc
@@ -2,7 +2,8 @@
 #DISTRO_FEATURES:append = " no_pixel_buffer_surfaces"
 
 # Enable YouTube 2025 support in Evergreen model
-DISTRO_FEATURES:append = " cobalt_enable_evergreen_lite"
+# This will enable evergreen lite.
+#DISTRO_FEATURES:append = " cobalt_enable_evergreen_lite"
 
 DISTRO_FEATURES:append = " cobalt-25"
 DISTRO_FEATURES:append = " enable_icrypto_openssl"

--- a/conf/rdk.inc
+++ b/conf/rdk.inc
@@ -1,10 +1,6 @@
 # Enable the distro to generate Cobalt-25 OCI image for devices that do not support pixel buffer surfaces
 #DISTRO_FEATURES:append = " no_pixel_buffer_surfaces"
 
-# Enable YouTube 2025 support in Evergreen model
-# This will enable evergreen lite.
-#DISTRO_FEATURES:append = " cobalt_enable_evergreen_lite"
-
 DISTRO_FEATURES:append = " cobalt-25"
 DISTRO_FEATURES:append = " enable_icrypto_openssl"
 DISTRO_FEATURES:append = " enable_rialto"

--- a/conf/rdk.inc
+++ b/conf/rdk.inc
@@ -1,6 +1,9 @@
 # Enable the distro to generate Cobalt-25 OCI image for devices that do not support pixel buffer surfaces
 #DISTRO_FEATURES:append = " no_pixel_buffer_surfaces"
 
+# Enable YouTube 2025 support in Evergreen lite mode
+#DISTRO_FEATURES:append = " cobalt_enable_evergreen_lite"
+
 DISTRO_FEATURES:append = " cobalt-25"
 DISTRO_FEATURES:append = " enable_icrypto_openssl"
 DISTRO_FEATURES:append = " enable_rialto"

--- a/meta-dac-image-cobalt/recipes-extended/cobalt/cobalt-launcher_git.bb
+++ b/meta-dac-image-cobalt/recipes-extended/cobalt/cobalt-launcher_git.bb
@@ -5,22 +5,22 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=256a42cf309d3ab8e25f221ae777f5cb"
 inherit cmake pkgconfig
 
 SRC_URI = "git://code.rdkcentral.com/r/rdk/components/generic/cobalt-launcher;protocol=https;branch=master"
-# Jan 26, 2024
-SRCREV = "7c7c6f33a561acac97414c7f2e4db843f6698d2c"
+# Sep 10, 2025
+SRCREV = "0c64e455a42ad8b51cb4c09e945c434f04eb8bc8"
 
 S = "${WORKDIR}/git"
 
 DEPENDS = "jsoncpp rpcserver jansson"
 
 PACKAGECONFIG ??= ""
-PACKAGECONFIG:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'cobalt_enable_evergreen_lite', 'evergreenlite', 'libcobalt', d)}"
+PACKAGECONFIG:append = " ${@bb.utils.contains('DISTRO_FEATURES', 'cobalt_enable_evergreen_lite', 'evergreenlite', 'evergreenfull', d)}"
 
 PACKAGECONFIG[evergreenlite]  = \
     "-DWSRPC_COBALT_EVERGREEN_LITE=ON, \
      -DWSRPC_COBALT_EVERGREEN_LITE=OFF, \
      libloader-app,virtual/cobalt-evergreen"
 
-PACKAGECONFIG[libcobalt]  = "-DWSRPC_COBALT_EVERGREEN_LITE=OFF,,libcobalt"
+PACKAGECONFIG[evergreenfull] = ",,libloader-app,virtual/cobalt-evergreen"
 
 do_install() {
     install -d ${D}${bindir}


### PR DESCRIPTION
Reason for change: YouTube 2025 must work in Full Evergreen mode
Test procedure: Refer ticket
Risks: low
Priority: P2